### PR TITLE
KB-21 Create new connection for each MySQL query

### DIFF
--- a/api/models/Database.js
+++ b/api/models/Database.js
@@ -1,26 +1,10 @@
+const getConnection = require('../util/getConnection');
+
 /**
  * @class Database
  * Handles MySQL generic database actions.
  */
 class Database {
-    /**
-     * Set the MySQL database connection.
-     * @param {Object} connection - The MySQL connection to run queries with.
-     */
-    setConnection(connection) {
-        this.connection = connection;
-        return this;
-    }
-
-    /**
-     * End the MySQL database connection.
-     * @param {Database} - Instance of the Database class.
-     */
-    endConnection() {
-        this.connection.end();
-        return this;
-    }
-
     /**
      * Set the name of the database to use.
      * @param {String} name - The name of the database to use.
@@ -50,7 +34,11 @@ class Database {
         log.debug('running MySQL query', {
             method: 'Database::query',
         });
-        return this.connection.query(query, cb);
+        this.connection = getConnection();
+        // Every method on a connection is queued and executed in sequence.
+        this.connection.connect();
+        this.connection.query(query, cb);
+        this.connection.end();
     }
 }
 

--- a/api/util/getDatabase.js
+++ b/api/util/getDatabase.js
@@ -1,11 +1,8 @@
 const Database = require('../models/Database');
 const getDatabaseName = require('./getDatabaseName');
-const getConnection = require('./getConnection');
 
 function getDatabase() {
-    return new Database()
-        .setConnection(getConnection())
-        .setName(getDatabaseName());
+    return new Database().setName(getDatabaseName());
 }
 
 module.exports = getDatabase;

--- a/test/functional/tests.js
+++ b/test/functional/tests.js
@@ -21,7 +21,6 @@ function clearTables(cb) {
 describe('Routes and database functionality', () => {
     beforeEach(done => clearTables(done));
     afterEach(done => clearTables(done));
-    after(() => db.endConnection());
 
     describe('Users tests', () => userTests());
     describe('Tech tests', () => techTests());

--- a/test/unit/database.js
+++ b/test/unit/database.js
@@ -11,8 +11,6 @@ describe('Database class', () => {
         db = getDatabase();
     });
 
-    afterEach(() => db.endConnection());
-
     it('should get instance of Database class', () => {
         assert.strictEqual(typeof db, 'object');
         assert.strictEqual(db.name, 'knowledgebase_test');


### PR DESCRIPTION
The production MySQL server periodically closes the database connection. This results in the an unhandled error event, causing the API server to crash. See logs:

```
2017-12-31T07:56:23.075829+00:00 app[web.1]: events.js:183
2017-12-31T07:56:23.075846+00:00 app[web.1]:       throw er; // Unhandled 'error' event
2017-12-31T07:56:23.075847+00:00 app[web.1]:       ^
2017-12-31T07:56:23.075848+00:00 app[web.1]:
2017-12-31T07:56:23.075849+00:00 app[web.1]: Error: Connection lost: The server closed the connection.
2017-12-31T07:56:23.075850+00:00 app[web.1]:     at Protocol.end (/app/node_modules/mysql/lib/protocol/Protocol.js:113:13)
2017-12-31T07:56:23.075851+00:00 app[web.1]:     at Socket.<anonymous> (/app/node_modules/mysql/lib/Connection.js:109:28)
2017-12-31T07:56:23.075851+00:00 app[web.1]:     at emitNone (events.js:111:20)
2017-12-31T07:56:23.075852+00:00 app[web.1]:     at Socket.emit (events.js:208:7)
2017-12-31T07:56:23.075853+00:00 app[web.1]:     at endReadableNT (_stream_readable.js:1056:12)
2017-12-31T07:56:23.082182+00:00 app[web.1]: error Command failed with exit code 1.
2017-12-31T07:56:23.075853+00:00 app[web.1]:     at _combinedTickCallback (internal/process/next_tick.js:138:11)
2017-12-31T07:56:23.082366+00:00 app[web.1]: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
2017-12-31T07:56:23.075854+00:00 app[web.1]:     at process._tickCallback (internal/process/next_tick.js:180:9)
2017-12-31T07:56:23.166776+00:00 heroku[web.1]: Process exited with status 1
2017-12-31T07:56:23.179344+00:00 heroku[web.1]: State changed from up to crashed
```

This PR fixes the above by creating a new connection for each database query and closing the connection once the query has been executed.